### PR TITLE
add custom fields to order entities as tags

### DIFF
--- a/src/converter.test.ts
+++ b/src/converter.test.ts
@@ -1,0 +1,79 @@
+import { createOrderEntity } from './converter';
+
+test('should create order entity', () => {
+  const orderEntity = createOrderEntity({
+    id: 42,
+    certificate: {
+      id: 4242,
+      common_name: 'foo.bar.com',
+      dns_names: ['foo.bar.com'],
+      valid_till: '2024-01-01',
+      days_remaining: 363,
+      signature_hash: 'sha512',
+    },
+    status: 'active',
+    is_renewed: true,
+    date_created: '2020-01-01T00:00:00Z',
+    organization: {
+      id: 42,
+      name: '42',
+      status: 'active',
+      display_name: 'DigiCert',
+      is_active: 'true',
+    },
+    validity_years: 1,
+    disable_renewal_notifications: false,
+    container: {
+      id: 42,
+      name: '42',
+    },
+    product: {
+      name_id: '42',
+      name: 'foo',
+      type: 'bar',
+    },
+    has_duplicates: true,
+    product_name_id: '4242',
+    custom_fields: [
+      {
+        metadata_id: 42,
+        label: 'foo',
+        value: '42',
+      },
+      {
+        metadata_id: 4242,
+        label: 'bar',
+        value: '4242',
+      },
+    ],
+  });
+
+  expect(orderEntity).toMatchObject({
+    _class: ['Certificate'],
+    _key: 'digicert_certificate:42',
+    _type: 'digicert_certificate',
+    active: true,
+    alternativeNames: ['foo.bar.com'],
+    certificateId: 4242,
+    createdOn: 1577836800000,
+    displayName: 'foo.bar.com',
+    dnsNames: ['foo.bar.com'],
+    domainName: 'foo.bar.com',
+    expiresOn: 1704067200000,
+    hasDuplicates: true,
+    id: '42',
+    issuedOn: false,
+    name: 'foo.bar.com',
+    orderId: 42,
+    productId: '42',
+    productName: 'foo',
+    renewalNotification: true,
+    renewed: true,
+    signatureHash: 'sha512',
+    status: 'active',
+    'tag.bar': '4242',
+    'tag.foo': '42',
+    type: 'bar',
+    validityYears: 1,
+  });
+});

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -8,10 +8,22 @@ import {
   DigiCertDomain,
   DigiCertOrder,
   DigiCertUser,
+  DigiCertOrderCustomField,
 } from './types';
 
 function createEntityKey(type: string, id: number | string): string {
   return `${type}:${id}`;
+}
+
+function createTagsBasedOnCustomFields(
+  customFields: DigiCertOrderCustomField[],
+) {
+  return customFields.reduce((acc, field) => {
+    return {
+      ...acc,
+      [`tag.${field.label}`]: field.value,
+    };
+  }, {});
 }
 
 export const createAccountEntity = (
@@ -129,6 +141,7 @@ export const createOrderEntity = (
           data.status === 'issued' && parseTimePropertyValue(data.date_created),
         createdOn: parseTimePropertyValue(data.date_created),
         expiresOn: parseTimePropertyValue(data.certificate.valid_till),
+        ...createTagsBasedOnCustomFields(data.custom_fields),
       },
     },
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,4 +137,11 @@ export interface DigiCertOrder {
   product: DigiCertProduct;
   has_duplicates: boolean;
   product_name_id: string;
+  custom_fields: DigiCertOrderCustomField[];
+}
+
+export interface DigiCertOrderCustomField {
+  metadata_id: number;
+  label: string;
+  value: string;
 }


### PR DESCRIPTION
# Description

Thank you for contributing to a JupiterOne integration!

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Summary

This PR contains a change to add the `custom_fields` to the DigiCert order objects (`_type = digicert_certificate`). The fields are added as `tags` in the entity, I'm not sure if this is the best practice. I can also add it as normal properties if you prefer, but could happen that a custom field will overwrite an existing property if has the same name.

I didn't do a sanity check, but the team is using the integration confirmed that the `/order/certificate` endpoint is returning the `custom_fields` property like:

```
custom_fields: [
  {
    metadata_id: 42,
    label: 'foo',
    value: '42',
  },
  {
    metadata_id: 4242,
    label: 'bar',
    value: '4242',
  },
]
```

Let me know if this requires more work, thanks.

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
